### PR TITLE
Remove unneeded instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,6 @@ EOF
 Then, some Docker magic:
 
 ```bash
-$ docker-compose pull
-$ docker-compose build
 $ docker-compose up -d
 ```
 


### PR DESCRIPTION
`docker-compose up -d` handles building and pulling so the separate commands aren't needed.