### PR TITLE
Version Bumps + Smaller Images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     build:
       context: orion-server
       args:
-        sha: 9c1430d6cd77e9ac16667d5b4c3e4a09f49ff5b7
+        sha: fedb85c8b2980bfc4dea7bf93ca17e059f63b1c1
         database_host: db
         database_port: 3306
         database_name: orion
@@ -28,7 +28,7 @@ services:
     build:
       context: orion-web
       args:
-        sha: ac4cb0c41a6a20a872dd7e07f664d9e7ead82b5d
+        sha: 8c18dce19a2199c4c53e1145881d362a05018cd5
         mapbox_api_token: ${MAPBOX_API_TOKEN}
     depends_on:
       - server

--- a/orion-web/Dockerfile
+++ b/orion-web/Dockerfile
@@ -5,9 +5,9 @@ ARG sha
 ARG mapbox_api_token
 
 RUN apk update
-RUN apk add wget unzip
+RUN apk add curl unzip
 
-RUN wget -O orion-web.zip https://github.com/LINKIWI/orion-web/archive/$sha.zip
+RUN wget -L -o orion-web.zip https://github.com/LINKIWI/orion-web/archive/$sha.zip
 RUN unzip orion-web.zip
 WORKDIR "orion-web-$sha"
 

--- a/orion-web/Dockerfile
+++ b/orion-web/Dockerfile
@@ -7,7 +7,7 @@ ARG mapbox_api_token
 RUN apk update
 RUN apk add curl unzip
 
-RUN wget -L -o orion-web.zip https://github.com/LINKIWI/orion-web/archive/$sha.zip
+RUN curl -L -o orion-web.zip https://github.com/LINKIWI/orion-web/archive/$sha.zip
 RUN unzip orion-web.zip
 WORKDIR "orion-web-$sha"
 

--- a/orion-web/Dockerfile
+++ b/orion-web/Dockerfile
@@ -1,11 +1,11 @@
-FROM node:8.9.3
+FROM node:8.9.3-alpine
 MAINTAINER Kevin Lin <developer@kevinlin.info>
 
 ARG sha
 ARG mapbox_api_token
 
-RUN apt-get update
-RUN apt-get install -y wget unzip
+RUN apk update
+RUN apk add wget unzip
 
 RUN wget -O orion-web.zip https://github.com/LINKIWI/orion-web/archive/$sha.zip
 RUN unzip orion-web.zip


### PR DESCRIPTION
- Bump to latest version of `orion-web` and `orion-server`
- Switch to node:8-alpine for a smaller docker image (984 MB -> 364 MB)