### PR TITLE
orion-server/Dockerfile: fix Python-MySQL error

### DIFF
--- a/orion-server/Dockerfile
+++ b/orion-server/Dockerfile
@@ -9,6 +9,7 @@ ARG database_user
 ARG database_password
 
 RUN apt-get update && apt-get install -y wget unzip python-dev default-libmysqlclient-dev gcc build-essential
+RUN sed '/st_mysql_options options;/a unsigned int reconnect;' /usr/include/mysql/mysql.h -i.bkp
 
 RUN wget -O orion-server.zip https://github.com/LINKIWI/orion-server/archive/$sha.zip
 RUN unzip orion-server.zip


### PR DESCRIPTION
```
    x86_64-linux-gnu-gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fno-strict-aliasing -Wdate-time -D_FORTIFY_SOURCE=2 -g -fdebug-prefix-map=/build/python2.7-tG19c8/python2.7-2.7.15=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -Dversion_info=(1,2,5,'final',1) -D__version__=1.2.5 -I/usr/include/mariadb -I/usr/include/mariadb/mysql -I/usr/include/python2.7 -c _mysql.c -o build/temp.linux-x86_64-2.7/_mysql.o
    In file included from _mysql.c:44:
    /usr/include/mariadb/my_config.h:3:2: warning: #warning This file should not be included by clients, include only <mysql.h> [-Wcpp]
     #warning This file should not be included by clients, include only <mysql.h>
      ^~~~~~~
    In file included from _mysql.c:46:
    /usr/include/mariadb/mysql.h:440:3: warning: function declaration isn't a prototype [-Wstrict-prototypes]
       MYSQL_CLIENT_PLUGIN_HEADER
       ^~~~~~~~~~~~~~~~~~~~~~~~~~
    _mysql.c: In function '_mysql_ConnectionObject_ping':
    _mysql.c:2005:41: error: 'MYSQL' {aka 'struct st_mysql'} has no member named 'reconnect'
      if ( reconnect != -1 ) self->connection.reconnect = reconnect;
                                             ^
    error: command 'x86_64-linux-gnu-gcc' failed with exit status 1
```